### PR TITLE
Fix BaseError.toJSON user message handling

### DIFF
--- a/src/BaseError.ts
+++ b/src/BaseError.ts
@@ -151,7 +151,7 @@ export class BaseError<T extends string> extends Error {
     };
 
     // Add user messages to the JSON output for logging if they exist
-    if (this._defaultUserMessage) {
+    if (this._defaultUserMessage !== undefined) {
       json.userMessage = this._defaultUserMessage;
     }
     if (this._localizedMessages.size > 0) {

--- a/src/__tests__/BaseError.test.ts
+++ b/src/__tests__/BaseError.test.ts
@@ -359,6 +359,16 @@ describe("BaseError", () => {
       expect(json).not.toHaveProperty("localizedMessages"); // Empty object should not be included
     });
 
+    it("should include empty default user message in JSON", () => {
+      const error = new TestError("Technical error message");
+
+      error.withUserMessage("");
+
+      const json = error.toJSON();
+
+      expect(json).toHaveProperty("userMessage", "");
+    });
+
     it("should support complex language codes", () => {
       const error = new TestError("Technical error message");
 


### PR DESCRIPTION
## Summary
- preserve empty user messages when serialising BaseError
- test that empty user messages are retained

## Testing
- `npm test -- -w=false`

------
https://chatgpt.com/codex/tasks/task_e_686954ced4cc832e9037a507e8128753